### PR TITLE
Switch to nuget.org

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="Orchestrator Extensibility" value="https://nuget.pkg.github.com/UiPath/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="UiPath.Core.Extensibility" Version="19.10" />
+    <PackageReference Include="UiPath.Orchestrator.Extensibility" Version="1.0.4" />
     (Other dependencies here)
   </ItemGroup>
 </Project>
@@ -114,11 +114,6 @@ Credential assets specific APIs are in the context of a `key`.  The key is the o
   3. Enabled plugin via updating [web.config](https://docs.uipath.com/orchestrator/v2019/docs/app-settings#section-password-vault) where
   `<add key="Plugins.SecureStores" value="YourSecureStore.dll"/>`
   4. Restart your Orchestrator instance.
-  
-  ## F.A.Q.
-  Q1: Why it requires authentication for "Orchestrator Extensibility" nuget feed?
-  
-  A: Currently GitHub Nuget feed is in beta and still requires authentication, even for public repos. See [the docs](https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-dotnet-cli-for-use-with-github-packages) for how to authenticate to the feed.
   
   ### License
   Current samples are available under [UiPath Open Platform License Agreement (“OPLA”)](https://github.com/UiPath/Orchestrator-CredentialStorePlugins-Samples/blob/master/UiPath_Activity_License_Agreement.pdf)

--- a/src/Example.Plugins.Tests/Example.Plugins.Tests.csproj
+++ b/src/Example.Plugins.Tests/Example.Plugins.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="System.Data.Odbc" Version="4.7.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
-    <PackageReference Include="UiPath.Orchestrator.Extensibility" Version="1.0.2" />
+    <PackageReference Include="UiPath.Orchestrator.Extensibility" Version="1.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />

--- a/src/Example1.RandomPass/Example1.RandomPass.csproj
+++ b/src/Example1.RandomPass/Example1.RandomPass.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="UiPath.Orchestrator.Extensibility" Version="1.0.2" />
+    <PackageReference Include="UiPath.Orchestrator.Extensibility" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resource.Designer.cs">

--- a/src/Example2.SqlPass/Example2.SqlPass.csproj
+++ b/src/Example2.SqlPass/Example2.SqlPass.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="System.Data.Odbc" Version="4.7.0" />
-    <PackageReference Include="UiPath.Orchestrator.Extensibility" Version="1.0.2" />
+    <PackageReference Include="UiPath.Orchestrator.Extensibility" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resource.Designer.cs">

--- a/src/SecureStore.AzureKeyVault/AzureKeyVault.SecureStore.csproj
+++ b/src/SecureStore.AzureKeyVault/AzureKeyVault.SecureStore.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.5.0" />
-    <PackageReference Include="UiPath.Orchestrator.Extensibility" Version="1.0.2" />
+    <PackageReference Include="UiPath.Orchestrator.Extensibility" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resource.Designer.cs">

--- a/src/SecureStore.CyberArkCCP/CyberArkCCP.SecureStore.csproj
+++ b/src/SecureStore.CyberArkCCP/CyberArkCCP.SecureStore.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="UiPath.Orchestrator.Extensibility" Version="1.0.2" />
+    <PackageReference Include="UiPath.Orchestrator.Extensibility" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\Resource.Designer.cs">


### PR DESCRIPTION
Using `nuget.org` to publish `UiPath.Orchestrator.Extensibility`. So we are getting rid of all the hassle that came with the github feed. No more github account, no more creating tokens, just create a project and reference `UiPath.Orchestrator.Extensibility` from Visual Studio, as you do with any other package.
The github feed will stay in place with existing packages, so as not to disrupt any projects already using it.