### PR TITLE
Token Creation Time reloading

### DIFF
--- a/src/SecureStore.HashicorpVault/HashicorpVaultClient.cs
+++ b/src/SecureStore.HashicorpVault/HashicorpVaultClient.cs
@@ -169,6 +169,7 @@ namespace UiPath.Orchestrator.Extensions.SecureStores.HashicorpVault
                 var tokenExpiryDate = _vaultClientCreationTime.AddSeconds(_vaultClient.Settings.AuthMethodInfo.ReturnedLoginAuthInfo.LeaseDurationSeconds);
                 if (tokenExpiryDate < DateTimeOffset.UtcNow.AddSeconds(30))
                 {
+                    _vaultClientCreationTime = DateTimeOffset.UtcNow;
                     _vaultClient.V1.Auth.ResetVaultToken();
                 }
             }


### PR DESCRIPTION
When vault resets the Token after a certain TTL (by default : 10 minutes), The CreationTime Variable must also be reloaded. Otherwise Vault will reset again and again Token after the first 10 minutes. This was tested in a large scale environement and it turned out to be a problem because Hashicorp does not like to create too many tokens.